### PR TITLE
Fix/version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ mvnw.cmd
 
 release.properties
 pom.xml.releaseBackup
+
+versioning.properties

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,5 @@ mvnw.cmd
 
 release.properties
 pom.xml.releaseBackup
-
-versioning.properties
+pom.xml.next
+pom.xml.tag

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,6 +121,8 @@ pipeline {
                         }
                         container('maven') {
                             sh "mvn -q -B release:prepare -DskipITs -Dmaven.test.redirectTestOutputToFile=true -Darguments=\"-B -DskipITs -Dmaven.test.redirectTestOutputToFile=true\""
+                            // Generates a file with the versioning to be used.
+                            sh "mvn -N org.codehaus.mojo:build-helper-maven-plugin:regex-property@strip-molgenis-version org.codehaus.mojo:build-helper-maven-plugin:parse-stripped-version@parse-version org.apache.maven.plugins:maven-antrun-plugin:run@versioning-file"
                         }
                     }
                 }
@@ -128,7 +130,7 @@ pipeline {
                     steps {
                         container('maven') {
                             script {
-                                env.TAG = sh(script: "grep project.rel release.properties | head -n1 | cut -d'=' -f2", returnStdout: true).trim()
+                                env.TAG = sh(script: "grep version.release versioning.properties | cut -d'=' -f2", returnStdout: true).trim()
                             }
                             // deploy RPM
                             // need to run install phase first

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,9 +120,7 @@ pipeline {
                             input(message: 'Prepare to release?')
                         }
                         container('maven') {
-                            sh "mvn -q -B release:prepare -DskipITs -Dmaven.test.redirectTestOutputToFile=true -Darguments=\"-B -DskipITs -Dmaven.test.redirectTestOutputToFile=true\""
-                            // Generates a file with the versioning to be used.
-                            sh "mvn -N org.codehaus.mojo:build-helper-maven-plugin:regex-property@strip-molgenis-version org.codehaus.mojo:build-helper-maven-plugin:parse-stripped-version@parse-version org.apache.maven.plugins:maven-antrun-plugin:run@versioning-file"
+                            sh "mvn -q -B initialize release:prepare -DskipITs -Dmaven.test.redirectTestOutputToFile=true -Darguments=\"-B -DskipITs -Dmaven.test.redirectTestOutputToFile=true\""
                         }
                     }
                 }
@@ -130,7 +128,7 @@ pipeline {
                     steps {
                         container('maven') {
                             script {
-                                env.TAG = sh(script: "grep version.release versioning.properties | cut -d'=' -f2", returnStdout: true).trim()
+                                env.TAG = sh(script: "grep project.rel release.properties | head -n1 | cut -d'=' -f2", returnStdout: true).trim()
                             }
                             // deploy RPM
                             // need to run install phase first

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                     steps {
                         container('maven') {
                             script {
-                                env.PREVIEW_VERSION = sh(script: "grep version pom.xml | grep SNAPSHOT | cut -d'>' -f2 | cut -d'<' -f1", returnStdout: true).trim() + "-${env.TAG}"
+                                env.PREVIEW_VERSION = sh(script: "mvn -q help:evaluate -Dexpression=project.version -DforceStdout", returnStdout: true) + "-${env.TAG}"
                             }
                             sh "mvn -q -B versions:set -DnewVersion=${PREVIEW_VERSION} -DgenerateBackupPoms=false"
                             sh "mvn -q -B clean install -Dmaven.test.redirectTestOutputToFile=true -DskipITs -T4"

--- a/molgenis-app-vibe/pom.xml
+++ b/molgenis-app-vibe/pom.xml
@@ -36,7 +36,7 @@
           <license>Apache License 2.0</license>
           <group>Application/Collectors</group>
           <packager>MOLGENIS</packager>
-          <name>${artifactId}</name>
+          <name>${project.artifactId}</name>
           <prefix>/usr/local</prefix>
           <changelogFile>CHANGELOG.md</changelogFile>
           <version>${rpm.release.version}</version>

--- a/molgenis-app-vibe/pom.xml
+++ b/molgenis-app-vibe/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.molgenis</groupId>
     <artifactId>molgenis-vibe</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>8.1.8-VIBE-1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>molgenis-app-vibe</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.molgenis</groupId>
   <artifactId>molgenis-vibe</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>8.1.8-VIBE-1.1.0-SNAPSHOT</version>
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.molgenis</groupId>
   <artifactId>molgenis-vibe</artifactId>
-  <version>8.1.8-VIBE-1.1.0-SNAPSHOT</version>
+  <version>8.1.8-VIBE-1.1.0-SNAPSHOT</version> <!-- first part should be equal to ${molgenis.version}!!! -->
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
@@ -47,6 +47,11 @@
   </issueManagement>
 
   <properties>
+    <!-- versioning -->
+    <version.release>${molgenis.version}-VIBE-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</version.release>
+    <version.development>${molgenis.version}-VIBE-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.nextIncrementalVersion}-SNAPSHOT</version.development>
+
+    <!-- molgenis version -->
     <molgenis.version>8.1.8</molgenis.version>
 
     <!-- authentication for release scm plugin -->
@@ -335,6 +340,52 @@
                 </sources>
               </configuration>
             </execution>
+            <!-- strips molgenis version from version string -->
+            <execution>
+              <id>strip-molgenis-version</id>
+              <goals>
+                <goal>regex-property</goal>
+              </goals>
+              <configuration>
+                <name>version.stripped</name>
+                <value>${project.version}</value>
+                <regex>${molgenis.version}-VIBE-</regex>
+                <replacement />
+                <failIfNoMatch>true</failIfNoMatch>
+              </configuration>
+            </execution>
+            <!-- parses stripped version string -->
+            <execution>
+              <id>parse-stripped-version</id>
+              <goals>
+                <goal>parse-version</goal>
+              </goals>
+              <configuration>
+                <versionString>${version.stripped}</versionString>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <!-- Generate properties file with versioning -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>versioning-file</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>run</goal>
+              </goals>
+              <configuration>
+                <target>
+                  <propertyfile file="versioning.properties">
+                    <entry key="version.release" value="${version.release}" />
+                    <entry key="version.development" value="${version.development}" />
+                  </propertyfile>
+                </target>
+              </configuration>
+            </execution>
           </executions>
         </plugin>
         <plugin>
@@ -508,6 +559,8 @@
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <scmCommentPrefix>[ci skip] [maven-release-plugin]${line.separator}</scmCommentPrefix>
+            <releaseVersion>${version.release}</releaseVersion>
+            <developmentVersion>${version.development}</developmentVersion>
           </configuration>
         </plugin>
         <plugin>
@@ -592,12 +645,20 @@
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>
-        <!-- add minified resources to build path -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
+          <!-- add minified resources to build path -->
           <execution>
             <id>minify-build-helper</id>
+          </execution>
+          <!-- strips the version to remove the initial molgenis version -->
+          <execution>
+            <id>strip-molgenis-version</id>
+          </execution>
+          <!-- parses the stripped version -->
+          <execution>
+            <id>parse-stripped-version</id>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,7 @@
             <!-- strips molgenis version from version string -->
             <execution>
               <id>strip-molgenis-version</id>
+              <phase>initialize</phase>
               <goals>
                 <goal>regex-property</goal>
               </goals>
@@ -357,33 +358,12 @@
             <!-- parses stripped version string -->
             <execution>
               <id>parse-stripped-version</id>
+              <phase>initialize</phase>
               <goals>
                 <goal>parse-version</goal>
               </goals>
               <configuration>
                 <versionString>${version.stripped}</versionString>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <!-- Generate properties file with versioning -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-antrun-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>versioning-file</id>
-              <phase>validate</phase>
-              <goals>
-                <goal>run</goal>
-              </goals>
-              <configuration>
-                <target>
-                  <propertyfile file="versioning.properties">
-                    <entry key="version.release" value="${version.release}" />
-                    <entry key="version.development" value="${version.development}" />
-                  </propertyfile>
-                </target>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
The `release.properties` file was validated on containing the correct version numbers through `mvn -B initialize release:prepare -DdryRun -DskipITs -Dmaven.test.redirectTestOutputToFile=true -Darguments="-B -DskipITs -Dmaven.test.redirectTestOutputToFile=true"`:
```
project.rel.org.molgenis\:molgenis-vibe=8.1.8-VIBE-1.1.0
project.rel.org.molgenis\:molgenis-app-vibe=8.1.8-VIBE-1.1.0
project.dev.org.molgenis\:molgenis-app-vibe=8.1.8-VIBE-1.1.1-SNAPSHOT
project.dev.org.molgenis\:molgenis-vibe=8.1.8-VIBE-1.1.1-SNAPSHOT
scm.tag=molgenis-vibe-8.1.8-VIBE-1.1.0
```

The version-number shown on the website (using a local SNAPSHOT) is as follows:
<img width="989" alt="Schermafbeelding 2021-03-23 om 13 06 38" src="https://user-images.githubusercontent.com/7658246/112143871-c341d380-8bd8-11eb-8994-a7e268f7da92.png">
 

In case actual releasing still results in missing version numbers, `initialize` might be needed in additional places in the `Jenkinsfile` to trigger the version-parsing.

- [ ] Functionality works & meets specs
- [ ] Code reviewed
- [ ] Documentation was updated

After merge:
- [ ] Added feature/fix to draft release notes
